### PR TITLE
Cut down on the size of the dictionary

### DIFF
--- a/src/Kaleidoscope/Leader.cpp
+++ b/src/Kaleidoscope/Leader.cpp
@@ -44,8 +44,13 @@ namespace KaleidoscopePlugins {
     for (uint8_t seqIndex = 0; ; seqIndex++) {
       match = true;
 
-      if (pgm_read_word (&(dictionary[seqIndex].sequence[0].raw)) == Key_NoKey.raw)
+      uint8_t sequenceLength = pgm_read_byte (&(dictionary[seqIndex].sequenceLength));
+
+      if (sequenceLength == 0)
         break;
+
+      if (sequenceLength < sequencePos)
+        continue;
 
       Key seqKey;
       for (uint8_t i = 0; i <= sequencePos; i++) {
@@ -60,8 +65,7 @@ namespace KaleidoscopePlugins {
       if (!match)
         continue;
 
-      seqKey.raw = pgm_read_word (&(dictionary[seqIndex].sequence[sequencePos + 1].raw));
-      if (seqKey.raw == Key_NoKey.raw) {
+      if (sequenceLength == sequencePos) {
         return seqIndex;
       } else {
         return PARTIAL_MATCH;

--- a/src/Kaleidoscope/Leader.h
+++ b/src/Kaleidoscope/Leader.h
@@ -25,15 +25,16 @@
 
 #define LEAD(n) (Key){ .raw = KaleidoscopePlugins::Ranges::LEAD_FIRST + n }
 
-#define LEADER_SEQ(...) { __VA_ARGS__, Key_NoKey }
-#define LEADER_DICT(...) { __VA_ARGS__, {{Key_NoKey}, NULL} }
+#define LEADER_SEQ(...) (sizeof ((Key[]) {__VA_ARGS__}) / sizeof (Key)), (Key []) {__VA_ARGS__}
+#define LEADER_DICT(...) { __VA_ARGS__, {0, NULL, NULL} }
 
 namespace KaleidoscopePlugins {
   class Leader : public KaleidoscopePlugin {
   public:
     typedef void (*action_t) (uint8_t seqIndex);
     typedef struct {
-      Key sequence[LEADER_MAX_SEQUENCE_LENGTH + 1];
+      uint8_t sequenceLength;
+      Key *sequence;
       action_t action;
     } dictionary_t;
 


### PR DESCRIPTION
Instead of forcing each sequence in the dictionary into a fixed-size array, use a variadic array, and an length field.