### PR TITLE
Type for leader dictionary in readme incorrect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ static void leaderTX() {
   Serial.println("leaderTX");
 }
 
-static const kaleidoscope::Leader::dictionary_t leader_dictionary PROGMEM =
+static const kaleidoscope::Leader::dictionary_t leader_dictionary[] PROGMEM =
   LEADER_DICT({LEADER_SEQ(LEAD(0), Key_A), leaderA},
               {LEADER_SEQ(LEAD(0), Key_T, Key_X), leaderTX});
 


### PR DESCRIPTION
Added array brackets so that type is a pointer instead of a single entry.